### PR TITLE
Fix: Make relative URLs absolute

### DIFF
--- a/plugin/bang.js
+++ b/plugin/bang.js
@@ -100,10 +100,14 @@ function bang(request, tab_id) {
         }
     }
 
-    function update_tab(URL) {
+    function update_tab(url) {
+        // `!blogspot` returns `/?q={{{s}}}+site:blogspot.com`
+        // Turn relative URLs like above into absolute URLs
+        // Already absolute URLs are left unchanged
+        url = new URL(url, 'https://duckduckgo.com/').href;
         var m = {
             loadReplace: replace,
-            url: URL
+            url,
         };
         if (tab_id != null) {
             chrome.tabs.update(tab_id, m);


### PR DESCRIPTION
`!blogspot` results in the relative URL `/?q=bang+site:blogspot.com`.
Redirecting to relative URLs breaks because it redirects to a URL like this `moz-extension://xxxxxxx/?q=query+here+site:blogspot.com`.

To fix this it makes all URLs absolute with the base URL `https://duckduckgo.com/`.
Already absolute URLs are left unchanged.

Fixes #23 