### PR TITLE
fix: use correct paramter for startpage

### DIFF
--- a/plugin/background.js
+++ b/plugin/background.js
@@ -3,19 +3,13 @@ chrome.webRequest.onBeforeRequest.addListener(
         console.log(info);
         var url_s = info.url;
         var url = new URL(url_s);
-        var search = null;
         //we dont want a bang to trigger bc qwant is giving us suggestions
         if(url_s.includes("qwant.com/v3/suggest")){
             return;
         }
-        if (url_s.includes("startpage.com/do/")) {
-           search = url.searchParams.get("query");;
-        } else {
-            search = url.searchParams.get("q");
-          
-        }
-          console.log(search);
-          match(url, search, info.tabId);
+        var search = url.searchParams.get("q");
+        console.log(search);
+        match(url, search, info.tabId);
     },
     // filters
     {


### PR DESCRIPTION
Startpage has changed their query parameter to `q`. For example, a request now looks like `https://www.startpage.com/do/dsearch?q=this+is+a+test+query&cat=web&language=english`, which breaks the extension.